### PR TITLE
Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# Changelog
+
+Notable changes to this project are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Breaking changes:
+
+New features:
+
+Bugfixes:
+
+Other improvements:
+
+# [Unreleased]
+
+Breaking changes:
+
+* Delete `writableClose` and add `end`.
+
+New features:
+
+* Add `toStringUTF8` and `fromStringUTF8`.
+
+Bugfixes:
+
+* Bugfix `onceError`.
 
 # v2.0.0
 

--- a/src/Node/Stream/Internal.js
+++ b/src/Node/Stream/Internal.js
@@ -14,14 +14,10 @@ export const onceDrain = s => f => () => {
 }
 
 export const onceError = s => f => () => {
-  s.once('error', f);
+  s.once('error', error => f(error)());
   return () => {s.removeListener('error', f);};
 }
 
 export const readable = s => () => {
     return s.readable;
-}
-
-export const writeStreamClose = s => cb => () => {
-  return s.close(cb);
 }

--- a/src/Node/Stream/Internal.purs
+++ b/src/Node/Stream/Internal.purs
@@ -7,7 +7,6 @@ module Node.Stream.Aff.Internal
   , onceError
   , onceReadable
   , readable
-  , writeStreamClose
   )
   where
 
@@ -65,18 +64,8 @@ foreign import onceError
 -- | property of a stream.
 -- |
 -- | > Is true if it is safe to call `readable.read()`, which means the stream
--- | > has not been destroyed or emitted 'error' or 'end'.
+-- | > has not been destroyed or emitted `'error'` or `'end'`.
 foreign import readable
   :: forall r
    . Readable r
   -> Effect Boolean
-
--- | The [`writeStream.close([callback])`](https://nodejs.org/api/fs.html#writestreamclosecallback)
--- | function.
--- |
--- | Accepts a callback that will be executed when the writeStream has closed.
-foreign import writeStreamClose
-  :: forall w
-   . Writable w
-  -> Effect Unit
-  -> Effect Unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -21,7 +21,7 @@ import Node.Buffer (Buffer, concat)
 import Node.Buffer as Buffer
 import Node.Encoding (Encoding(..))
 import Node.FS.Stream (createReadStream, createWriteStream)
-import Node.Stream.Aff (readAll, readN, readSome, writableClose, write)
+import Node.Stream.Aff (end, readAll, readN, readSome, write)
 import Partial.Unsafe (unsafePartial)
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (expectError, shouldEqual)
@@ -62,7 +62,7 @@ main = unsafePartial $ do
           outfile <- liftEffect $ createWriteStream outfilename
           b <- liftEffect $ Buffer.fromString "test" UTF8
           write outfile [b]
-          writableClose outfile
+          end outfile
           expectError $ write outfile [b]
 
     pure (pure unit)


### PR DESCRIPTION
* Delete `writableClose` and add `end`.
* Add `toStringUTF8` and `fromStringUTF8`.
* Bugfix `onceError`.

Resolves #3 #4